### PR TITLE
Update C compilers

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -31,7 +31,7 @@ install:
 - conda install python=$TRAVIS_PYTHON_VERSION
 - conda install -q conda-build anaconda-client coverage sphinx
 script:
-- conda build ./recipe -c csdms-stack -c conda-forge --old-build-string
+- conda build ./recipe -c csdms-stack -c defaults -c conda-forge --old-build-string
 after_success:
 - curl https://raw.githubusercontent.com/csdms/ci-tools/master/anaconda_upload.py > $HOME/anaconda_upload.py
 - echo $ANACONDA_TOKEN | python $HOME/anaconda_upload.py ./recipe --channel=main --org=csdms-stack --old-build-string --token=-

--- a/recipe/build.sh
+++ b/recipe/build.sh
@@ -1,8 +1,5 @@
 #! /bin/bash
 
-export CC=$(which gcc)
-export CXX=$(which g++)
-
 mkdir _build && cd _build
 cmake .. -DCMAKE_INSTALL_PREFIX=$PREFIX
 make -j$CPU_COUNT all

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -12,7 +12,8 @@ source:
 requirements:
   build:
     - cmake
-    - gcc # [not win]
+    - clangxx_osx-64 [osx]
+    - gxx_linux-64 [linux]
   run:
     - libgcc
 
@@ -24,7 +25,7 @@ test:
     - hydrotrend --prefix=HYDRO --in-dir=. --out-dir=.
 
 build:
-  number: 3
+  number: 4
 
 about:
   home: http://csdms.colorado.edu/wiki/Model:HydroTrend


### PR DESCRIPTION
Apparently the conda `gcc` package has been deprecated in favor of `gxx_linux-64` and `clangxx_osx-64` (see https://github.com/ContinuumIO/anaconda-issues/issues/5191#issuecomment-338482506).

Also, when building with `conda-build`, we now look first to the default channel channel before the conda-forge channel.

Updated build number for these changes.