### PR TITLE
Use CircleCI for Linux

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -34,4 +34,7 @@ script:
 - conda build ./recipe -c csdms-stack -c defaults -c conda-forge --old-build-string
 after_success:
 - curl https://raw.githubusercontent.com/csdms/ci-tools/master/anaconda_upload.py > $HOME/anaconda_upload.py
-- echo $ANACONDA_TOKEN | python $HOME/anaconda_upload.py ./recipe --channel=main --org=csdms-stack --old-build-string --token=-
+- |
+  if [[ "$TRAVIS_OS_NAME" == "osx" ]]; then
+    echo $ANACONDA_TOKEN | python $HOME/anaconda_upload.py ./recipe --channel=main --org=csdms-stack --old-build-string --token=-
+  fi

--- a/ci/run_docker_build.sh
+++ b/ci/run_docker_build.sh
@@ -13,9 +13,9 @@ docker info
 config=$(cat <<CONDARC
 
 channels:
- - conda-forge
  - csdms-stack
  - defaults # As we need conda-build
+ - conda-forge
 
 conda-build:
  root-dir: /feedstock_root/build_artefacts
@@ -42,7 +42,8 @@ conda clean --lock
 
 conda config --set always_yes yes --set changeps1 no
 conda install python=2.7
-conda install -q conda-build anaconda-client coverage sphinx
+conda install -q 'conda-build>=3'
+conda install -q anaconda-client coverage sphinx
 
 conda build /recipe_root --quiet || exit 1
 


### PR DESCRIPTION
Revert to using CircleCI for Linux builds. Still build on Linux with Travis, but don't upload to Anaconda Cloud.